### PR TITLE
fix brush arguments to invert categorical

### DIFF
--- a/src/brush/1d/brushFor.js
+++ b/src/brush/1d/brushFor.js
@@ -22,13 +22,35 @@ const brushFor = (state, config, pc, events, brushGroup) => (
 
   const _brush = brushY(_selector).extent([[-15, 0], [15, brushRangeMax]]);
 
+  const invertCategorical = (selection, yscale) => {
+    if (selection.length === 0) {
+      return [];
+    }
+    const domain = yscale.domain();
+    const range = yscale.range();
+    const found = [];
+    range.forEach((d, i) => {
+      if (d >= selection[0] && d <= selection[1]) {
+        found.push(domain[i]);
+      }
+    });
+    return found;
+  };
+
   const convertBrushArguments = args => {
     const args_array = Array.prototype.slice.call(args);
     const axis = args_array[0];
     const selection_raw = brushSelection(args_array[2][0]) || [];
-    const selection_scaled = selection_raw.map(d =>
-      config.dimensions[axis].yscale.invert(d)
-    );
+    // ordinal scales do not have invert
+    let selection_scaled = [];
+    const yscale = config.dimensions[axis].yscale;
+    if (typeof yscale.invert === 'undefined') {
+      selection_scaled = invertCategorical(selection_raw, yscale);
+    } else {
+      selection_scaled = selection_raw.map(d =>
+        config.dimensions[axis].yscale.invert(d)
+      );
+    }
 
     return {
       axis: args_array[0],


### PR DESCRIPTION
fix #44 for categorical scales since `d3.scaleOrdinal` does not invert