### PR TITLE
Fix snapshot from mergeParcoords

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -94,6 +94,9 @@
         <li>
             <a href="brush-with-arguments.html">brush with arguments</a>
         </li>
+        <li>
+            <a href="snapshot.html">snapshot</a>
+        </li>
     </ul>
 </body>
 </html>

--- a/demo/snapshot.html
+++ b/demo/snapshot.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+</head>
+<title>Brushing Example</title>
+<link rel="stylesheet" type="text/css" href="./parcoords.css">
+<link rel="stylesheet" type="text/css" href="style.css">
+<script src="./lib/d3.v5.min.js"></script>
+<script src="./parcoords.standalone.js"></script>
+<div id="example" class="parcoords" style="width:960px;height:200px;"></div>
+<p>Loads an external <a href="data/cars.csv">csv file</a>, creates a custom <a
+        href="https://github.com/mbostock/d3/wiki/Quantitative-Scales#wiki-quantitative">quantitative color scale</a>
+    using <a href="http://bl.ocks.org/3014589">L*a*b interpolation</a>, and enables brushing.
+
+<h3>Snapshot</h3>
+<p>Parallel coordinates includes <code>mergeParcoords</code> to produce a snapshot.
+  <button onclick="createSnapshot()">snapshot</button>
+</p>
+
+<script>
+    // quantitative color scale
+    var blue_to_brown = d3.scaleLinear()
+        .domain([9, 50])
+        .range(["steelblue", "brown"])
+        .interpolate(d3.interpolateLab);
+
+    var color = function (d) {
+        return blue_to_brown(d['economy (mpg)']);
+    };
+
+    var parcoords = ParCoords()("#example")
+        .alpha(0.4);
+
+    // load csv file and create the chart
+    d3.csv('data/cars.csv').then(function(data) {
+        parcoords
+            .data(data)
+            .hideAxis(["name"])
+            .composite("darker")
+            .render()
+            .shadows()
+            .reorderable()
+            .brushMode("1D-axes");  // enable brushing
+    });
+
+    function createSnapshot() {
+      parcoords.mergeParcoords(function(canvas) {document.body.append(canvas)});
+    }
+</script>
+
+
+

--- a/src/api/mergeParcoords.js
+++ b/src/api/mergeParcoords.js
@@ -1,3 +1,5 @@
+import {select, selectAll} from 'd3-selection';
+
 // Merges the canvases and SVG elements into one canvas element which is then passed into the callback
 // (so you can choose to save it to disk, etc.)
 const mergeParcoords = pc => callback => {
@@ -10,13 +12,12 @@ const mergeParcoords = pc => callback => {
   const foregroundCanvas = pc.canvas.foreground;
   // We will need to adjust for canvas margins to align the svg and canvas
   const canvasMarginLeft = Number(foregroundCanvas.style.marginLeft.replace('px',''));
-  // In addition we will need to consider the negative translation on axis titles
-  //   by default parcoords will translate(0,-5) so we will add this
-  const textTopAdjust = 25;
+
+  const textTopAdjust = 15;
   const canvasMarginTop = Number(foregroundCanvas.style.marginTop.replace('px','')) + textTopAdjust;
   const width = (foregroundCanvas.clientWidth + canvasMarginLeft) * devicePixelRatio;
   const height = (foregroundCanvas.clientHeight + canvasMarginTop) * devicePixelRatio;
-  mergedCanvas.width = width;
+  mergedCanvas.width = width + 50; // pad so that svg labels at right will not get cut off
   mergedCanvas.height = height + 30; // pad so that svg labels at bottom will not get cut off
   mergedCanvas.style.width = mergedCanvas.width / devicePixelRatio + 'px';
   mergedCanvas.style.height = mergedCanvas.height / devicePixelRatio + 'px';
@@ -45,8 +46,11 @@ const mergeParcoords = pc => callback => {
   const svgNodeCopy = pc.selection.select('svg').node().cloneNode(true);
   svgNodeCopy.setAttribute('transform', 'translate(0,' + textTopAdjust + ')');
   svgNodeCopy.setAttribute('height', svgNodeCopy.getAttribute('height') + textTopAdjust);
+  // text will need fill attribute since css styles will not get picked up
+  //   this is not sophisticated since it doesn't look up css styles
+  //   if the user changes
+  select(svgNodeCopy).selectAll('text').attr('fill', 'black');
   const svgStr = serializer.serializeToString(
-    //pc.selection.select('svg').node()
     svgNodeCopy
   );
 


### PR DESCRIPTION
`mergeParcoords` hardcodes margins to the defaults rather than adjusting for user-specified margins.  This pull request changes `mergeParcoords` to accommodate non-default margins.

In addition, some `text` labels did not show up since `css` styling of `svg` is not drawn to canvas.  This pull in an unsophisticated way adds `fill` attribute as `black` so the text appears in the snapshot.  If we want to get more sophisticated, we can use or borrow from [svg-crowbar](https://bl.ocks.org/mbostock/6466603).

Below is a screenshot that I added to demo.

![image](https://user-images.githubusercontent.com/837910/47195772-ffdfb580-d322-11e8-99f8-88b6c256438a.png)
