### PR TITLE
Enable programmatic use of flipAxes(), address #50

### DIFF
--- a/src/bindEvents.js
+++ b/src/bindEvents.js
@@ -30,6 +30,7 @@ const bindEvents = (
     ctx,
     pc,
     xscale,
+    axis,
     flags,
     brushedQueue,
     markedQueue,

--- a/src/state/sideEffects.js
+++ b/src/state/sideEffects.js
@@ -15,6 +15,7 @@ const sideEffects = (
   ctx,
   pc,
   xscale,
+  axis,
   flags,
   brushedQueue,
   markedQueue,
@@ -76,8 +77,8 @@ const sideEffects = (
     })
     .on('flipAxes', d => {
       if (d.value && d.value.length) {
-        d.value.forEach(function(axis) {
-          flipAxisAndUpdatePCP(config, pc, axis);
+        d.value.forEach(function(dimension) {
+          flipAxisAndUpdatePCP(config, pc, axis)(dimension);
         });
         pc.updateAxes(0);
       }

--- a/src/util/flipAxisAndUpdatePCP.js
+++ b/src/util/flipAxisAndUpdatePCP.js
@@ -1,10 +1,19 @@
-import { select } from 'd3-selection';
+import { select, selectAll } from 'd3-selection';
 
 const flipAxisAndUpdatePCP = (config, pc, axis) =>
   function(dimension) {
     pc.flip(dimension);
     pc.brushReset(dimension);
-    select(this.parentElement)
+
+    // select(this.parentElement)
+    pc.selection
+      .select('svg')
+      .selectAll('g.axis')
+      .filter(function(d) {
+        if (d === dimension) {
+          return d;
+        }
+      })
       .transition()
       .duration(config.animationTime)
       .call(axis.scale(config.dimensions[dimension].yscale));

--- a/src/util/flipAxisAndUpdatePCP.js
+++ b/src/util/flipAxisAndUpdatePCP.js
@@ -9,11 +9,7 @@ const flipAxisAndUpdatePCP = (config, pc, axis) =>
     pc.selection
       .select('svg')
       .selectAll('g.axis')
-      .filter(function(d) {
-        if (d === dimension) {
-          return d;
-        }
-      })
+      .filter(d => d === dimension)
       .transition()
       .duration(config.animationTime)
       .call(axis.scale(config.dimensions[dimension].yscale));


### PR DESCRIPTION
This approach to `flipAxisAndUpdatePCP` allows the function to be compatible with the double-click event based approach as well as the programmatic approach in the `flipAxes` side effect.