### PR TITLE
fix lingering issues from #57 following @timelyportfolio's approach

### DIFF
--- a/src/brush/1d/brushFor.js
+++ b/src/brush/1d/brushFor.js
@@ -13,16 +13,17 @@ const brushFor = (state, config, pc, events, brushGroup) => (
   axis,
   _selector
 ) => {
-  // handle hidden axes which will not be found in dimensions
-  let brushRangeMax = null;
-  if (config.dimensions.hasOwnProperty(axis)) {
-    brushRangeMax =
-      config.dimensions[axis].type === 'string'
-        ? config.dimensions[axis].yscale.range()[
-            config.dimensions[axis].yscale.range().length - 1
-          ]
-        : config.dimensions[axis].yscale.range()[0];
+  // handle hidden axes which will not be a property of dimensions
+  if (!config.dimensions.hasOwnProperty(axis)) {
+    return () => {}
   }
+
+  const brushRangeMax =
+    config.dimensions[axis].type === 'string'
+      ? config.dimensions[axis].yscale.range()[
+          config.dimensions[axis].yscale.range().length - 1
+        ]
+      : config.dimensions[axis].yscale.range()[0];
 
   const _brush = brushY(_selector).extent([[-15, 0], [15, brushRangeMax]]);
 

--- a/src/brush/1d/brushFor.js
+++ b/src/brush/1d/brushFor.js
@@ -13,12 +13,16 @@ const brushFor = (state, config, pc, events, brushGroup) => (
   axis,
   _selector
 ) => {
-  const brushRangeMax =
-    config.dimensions[axis].type === 'string'
-      ? config.dimensions[axis].yscale.range()[
-          config.dimensions[axis].yscale.range().length - 1
-        ]
-      : config.dimensions[axis].yscale.range()[0];
+  // handle hidden axes which will not be found in dimensions
+  let brushRangeMax = null;
+  if (config.dimensions.hasOwnProperty(axis)) {
+    brushRangeMax =
+      config.dimensions[axis].type === 'string'
+        ? config.dimensions[axis].yscale.range()[
+            config.dimensions[axis].yscale.range().length - 1
+          ]
+        : config.dimensions[axis].yscale.range()[0];
+  }
 
   const _brush = brushY(_selector).extent([[-15, 0], [15, brushRangeMax]]);
 


### PR DESCRIPTION
I was still having issues when an array of axes that included the rightmost axis was hidden. This gave the error `TypeError: Cannot read property 'type' of undefined` from this line in `brushFor.js`:
```javascript
brushRangeMax = config.dimensions[axis].type 
```
I followed the same approach released in [v2.2.5](https://github.com/BigFatDog/parcoords-es/releases/tag/v2.2.5) to correct this.