### PR TITLE
Account for hidden axes in brushReset

### DIFF
--- a/src/brush/1d/brushReset.js
+++ b/src/brush/1d/brushReset.js
@@ -9,7 +9,9 @@ const brushReset = (state, config, pc) => dimension => {
       pc.g()
         .selectAll('.brush')
         .each(function(d) {
-          select(this).call(brushes[d].move, null);
+          if (brushes[d] !== undefined) {
+            select(this).call(brushes[d].move, null);
+          }
         });
       pc.renderBrushed();
     }


### PR DESCRIPTION
Attempting to access hidden dimensions in `state.brushes` throws an error since they are not included in the brushes object. This small change just ignores hidden dimensions when moving brushes. 