### PR TITLE
Update CSS location to reflect where npm installs it

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm install parcoord-es --save
 2. import module
 
 ```
-import 'parcoord-es/parcoords.css';
+import 'parcoord-es/dist/parcoords.css';
 import ParCoords from 'parcoord-es';
 
 const chart = ParCoords()....


### PR DESCRIPTION
After installing the package in our React app it could not locate the file when we followed the instructions in the README. This corrects the path to match where npm installs it